### PR TITLE
feat: add post init scripts hooks

### DIFF
--- a/postgres-appliance/runit/patroni/run
+++ b/postgres-appliance/runit/patroni/run
@@ -21,7 +21,7 @@ fi
 ulimit -c unlimited || true
 
 # Only small subset of environment variables is allowed. We don't want accidentally disclose sensitive information
-for E in $(printenv -0 | tr '\n' ' ' | sed 's/\x00/\n/g' | grep -vE '^(KUBERNETES_(SERVICE|PORT|ROLE)[_=]|((POD_(IP|NAMESPACE))|HOSTNAME|PATH|PGHOME|LC_ALL|ENABLE_PG_MON)=)' | sed 's/=.*//g'); do
+for E in $(printenv -0 | tr '\n' ' ' | sed 's/\x00/\n/g' | grep -vE '^(KUBERNETES_(SERVICE|PORT|ROLE)[_=]|((POD_(IP|NAMESPACE))|HOSTNAME|PATH|PGHOME|LC_ALL|ENABLE_PG_MON|POST_INIT_EXEC_DIR)=)' | sed 's/=.*//g'); do
     unset $E
 done
 

--- a/postgres-appliance/scripts/post_init.sh
+++ b/postgres-appliance/scripts/post_init.sh
@@ -197,3 +197,18 @@ GRANT EXECUTE ON FUNCTION public.pg_stat_statements_reset($RESET_ARGS) TO admin;
     cat metric_helpers.sql
 done < <(psql -d "$2" -tAc 'select pg_catalog.quote_ident(datname) from pg_catalog.pg_database where datallowconn')
 ) | psql -Xd "$2"
+
+post_init_exec_dir="$HOME/.config/patroni/post_init.d"
+if [[ -v POST_INIT_EXEC_DIR && -d "${POST_INIT_EXEC_DIR}" ]]; then
+    post_init_exec_dir="${POST_INIT_EXEC_DIR}"
+fi
+if [[ -d "${post_init_exec_dir}" ]]; then
+    echo "Executing extra post init scripts in '${post_init_exec_dir}'"
+    for post_init_script in "${post_init_exec_dir}"/* ; do
+        if [[ -x "${post_init_script}" ]]; then
+            if ! "${post_init_script}"; then
+                echo "Executing post init script '${post_init_script}' failed" >&2
+            fi
+        fi
+    done
+fi


### PR DESCRIPTION
Add post init script hooks, so that in KubeBlocks add-ons, we can tweak our post-init logics according to business needs.  