### PR TITLE
chore: add zh_CN.UTF-8 locale support in Docker image build

### DIFF
--- a/postgres-appliance/build_scripts/base.sh
+++ b/postgres-appliance/build_scripts/base.sh
@@ -134,7 +134,7 @@ for version in $DEB_PG_SUPPORTED_VERSIONS; do
 
     exclude_patterns=()
     versions=$(find "/usr/lib/postgresql/$version/lib/" -name 'timescaledb-2.*.so' | sed -rn 's/.*timescaledb-([1-9]+\.[0-9]+\.[0-9]+)\.so$/\1/p' | sort -rV)
-    
+
     # Calculate the number of versions dynamically based on the lowest PG version's latest minor
     num_versions=5
     if [ -n "$first_latest_minor" ]; then
@@ -148,13 +148,13 @@ for version in $DEB_PG_SUPPORTED_VERSIONS; do
                 break
             fi
         done <<< "$minor_versions"
-        
+
         # if found, keep max(5, position) versions (so all versions have at least 1 version in common with lowest PG version)
         if [ $found -eq 1 ] && [ $position -gt $num_versions ]; then
             num_versions=$position
         fi
     fi
-    
+
     latest_minor_versions=$(echo "$versions" | awk -F. '{print $1"."$2}' | uniq | head -n "$num_versions")
     for minor in $latest_minor_versions; do
         for full_version in $(echo "$versions" | grep "^$minor"); do
@@ -234,6 +234,11 @@ apt-get purge -y \
 apt-get autoremove -y
 apt-get clean
 dpkg -l | grep '^rc' | awk '{print $2}' | xargs apt-get purge -y
+
+# Generate zh_CN.UTF-8 locale
+apt-get install -y locales
+echo "zh_CN.UTF-8 UTF-8" >> /etc/locale.gen
+locale-gen
 
 # Try to minimize size by creating symlinks instead of duplicate files
 if [ "$DEMO" != "true" ]; then
@@ -317,8 +322,6 @@ rm -rf /var/lib/apt/lists/* \
         /usr/share/doc \
         /usr/share/man \
         /usr/share/info \
-        /usr/share/locale/?? \
-        /usr/share/locale/??_?? \
         /usr/share/postgresql/*/man \
         /etc/pgbouncer/* \
         /usr/lib/postgresql/*/bin/createdb \
@@ -329,4 +332,6 @@ rm -rf /var/lib/apt/lists/* \
         /usr/lib/postgresql/*/bin/dropuser \
         /usr/lib/postgresql/*/bin/pg_standby \
         /usr/lib/postgresql/*/bin/pltcl_*
+# Remove locale dirs except zh/zh_CN (needed for zh_CN.UTF-8 support)
+find /usr/share/locale -maxdepth 1 -mindepth 1 \( -name '??' -o -name '??_??' \) ! -name 'zh' ! -name 'zh_CN' -exec rm -rf {} +
 find /var/log -type f -exec truncate --size 0 {} \;


### PR DESCRIPTION
## 问题背景

在 PostgreSQL 中执行以下 SQL 时报错：

```sql
CREATE DATABASE nacos_ct1 TEMPLATE 'template0' LOCALE 'zh_CN.UTF-8' ENCODING 'UTF8';
```

报错信息：`invalid locale name: "zh_CN.UTF-8"`

## 根本原因

PostgreSQL 在处理 `CREATE DATABASE ... LOCALE` 时会调用操作系统的 `setlocale()` 验证 locale 是否存在。原来的 Docker 镜像构建脚本中：

1. 没有生成 `zh_CN.UTF-8` locale（未调用 `locale-gen`）
2. 清理阶段通过 `rm -rf /usr/share/locale/??` 和 `/usr/share/locale/??_??` 通配符删除了所有二字母语言目录（包括 `zh` 和 `zh_CN`）

导致容器内操作系统完全不支持中文 locale，PostgreSQL 自然无法识别。

## 修复方案

**1. 生成 `zh_CN.UTF-8` locale**

在 `apt-get clean` 之后新增：

```bash
apt-get install -y locales
echo "zh_CN.UTF-8 UTF-8" >> /etc/locale.gen
locale-gen
```

`locale-gen` 会将编译后的 locale 数据写入 `/usr/lib/locale/zh_CN.utf8/`，这正是 `setlocale()` 读取的路径，后续清理阶段不会触及该目录。

**2. 清理阶段保留中文 locale 目录**

将原来的通配符删除：

```bash
rm -rf /usr/share/locale/?? /usr/share/locale/??_??
```

改为使用 `find` 排除 `zh` 和 `zh_CN`：

```bash
find /usr/share/locale -maxdepth 1 -mindepth 1 \( -name '??' -o -name '??_??' \) ! -name 'zh' ! -name 'zh_CN' -exec rm -rf {} +
```

## 验证方法

镜像构建完成后，在容器内执行：

```bash
locale -a | grep zh
# 预期输出：zh_CN.utf8
```

之后 `CREATE DATABASE ... LOCALE 'zh_CN.UTF-8'` 即可正常执行。
